### PR TITLE
added missing ids in checkbox inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,13 +304,13 @@
 										</td>
 										<td>
 											<label class="form-check-label hover-parent d-block">
-												<input class="form-check-input" type="checkbox" value="true">
+												<input class="form-check-input" id="female-check-{{ index }}" type="checkbox" value="true">
 												<i class="fa fa-venus parent-hover-visible" aria-hidden="true"></i><span class="sr-only">Frau</span>
 											</label>
 										</td>
 										<td>
 											<label class="form-check-label hover-parent d-block">
-												<input class="form-check-input" type="checkbox" value="true">
+												<input class="form-check-input" id="diverse-check-{{ index }}" type="checkbox" value="true">
 												<i class="fa fa-snowflake-o parent-hover-visible" aria-hidden="true"></i><span class="sr-only">Vielfalt</span>
 											</label>
 										</td>


### PR DESCRIPTION
Preconfigured values for the "female" and "diverse" properties weren't being applied because the code that applies them was trying to find the corresponding checkbox inputs by their ids, which were missing.