### PR TITLE
take into account change in result structure

### DIFF
--- a/js/lib/dibElectionsTool.js
+++ b/js/lib/dibElectionsTool.js
@@ -1387,9 +1387,9 @@
 					else {
 						// all following elections if results copy into previous
 						var previousI = i - 1;
-						if ( typeof currentElectionConfig[ key ][ previousI ].results !== 'undefined' && currentElectionConfig[ key ][ previousI ].results.length > 0 ) {
-							for ( var k = 0; k < currentElectionConfig[ key ][ previousI ].results.length; k++ ) {
-								electionCalculationInput.previous.push( currentElectionConfig[ key ][ previousI ].results[ k ] );
+						if ( typeof currentElectionConfig[ key ][ previousI ].results !== 'undefined' && currentElectionConfig[ key ][ previousI ].results.candidates.length > 0 ) {
+							for ( var k = 0; k < currentElectionConfig[ key ][ previousI ].results.candidates.length; k++ ) {
+								electionCalculationInput.previous.push( currentElectionConfig[ key ][ previousI ].results.candidates[ k ] );
 							}
 						}
 					}


### PR DESCRIPTION
The code that copies the previous results was still assuming the old result structure; it needs to use results.candidates instead.